### PR TITLE
[유상호]Add: 상세페이지 피규어 Ui 및 반응형 추가

### DIFF
--- a/src/components/DetailInfo/index.tsx
+++ b/src/components/DetailInfo/index.tsx
@@ -10,6 +10,7 @@ import Bottom from './Bottom';
 import NotFound from '../NotFound';
 import styled from 'styled-components';
 import DetailSkeleton from './DetailSkeleton';
+import Figure from '../../unused/sanghoU/Figure';
 
 const DetailInfo = () => {
   const [detailData, setDetailData] = useState<ThemeDetail>();
@@ -35,6 +36,7 @@ const DetailInfo = () => {
           {detailData ? (
             <>
               <Info detailData={detailData} />
+              <Figure figureData={detailData.figure} />
               <Bottom priceData={detailData.price} />
             </>
           ) : (

--- a/src/unused/sanghoU/Figure.tsx
+++ b/src/unused/sanghoU/Figure.tsx
@@ -1,0 +1,81 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+interface FigureProps {
+  figureData: {
+    keyword: string;
+    text: string;
+    imageUrl: string;
+  }[];
+}
+
+const List = ({ figureData }: FigureProps) => {
+  return (
+    <Div>
+      <AD>AD</AD>
+      {figureData.length > 0 && (
+        <>
+          <CardList>
+            {figureData.map(figure => (
+              <img key={figure.imageUrl} src={figure.imageUrl} alt={figure.keyword} />
+            ))}
+          </CardList>
+          <Text>
+            일부 앱에서는 움짤 형태로 전송되거나, 멈춰있는 이모티콘으로 전송될 수 있어요.
+            <Question to=''>이모티콘은 어떻게 전송하나요?</Question>
+          </Text>
+        </>
+      )}
+    </Div>
+  );
+};
+
+const Div = styled.div`
+  max-width: 600px;
+  padding: 0 16px;
+  margin: 0 auto;
+`;
+
+const AD = styled.button`
+  width: 100%;
+  min-height: 30px;
+  height: 4vh;
+  margin: 10px 0;
+  border: none;
+  background: #d9d9d9;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+`;
+
+const CardList = styled.div`
+  img {
+    width: 30%;
+    margin: 0 calc(10% / 6);
+
+    @media screen and (max-width: 500px) {
+      width: 45%;
+      margin: 0 calc(10% / 4);
+    }
+  }
+`;
+
+const Text = styled.p`
+  display: block;
+  width: 77%;
+  margin: 40px auto 0 auto;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 24px;
+  text-align: center;
+  color: #919299;
+`;
+
+const Question = styled(Link)`
+  display: block;
+  color: #4b4e57;
+  text-decoration: underline;
+  margin-top: 5px;
+`;
+
+export default List;


### PR DESCRIPTION
## **: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)**

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

## **:: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)**

1. 상세페이지 피규어 ui, 반응형 추가

- 피규어 데이터가 있을때에 보여짐
- 스크린 가로길이가 500px 이하일때는 한줄에 2개씩 500px 이상일때는 3개씩 보여지게 설정
